### PR TITLE
Added include header protection

### DIFF
--- a/demos/openmp/sample.c
+++ b/demos/openmp/sample.c
@@ -3,11 +3,15 @@
 #include "mpi.h"
 #include "quo.h"
 #include <omp.h>
- <sched.h>
+#include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
+#endif
+#ifdef HAVE_SYSCALL_H
 #include <sys/syscall.h>
+#endif
 #include <unistd.h>
 
 QUO_context context;


### PR DESCRIPTION
For some reason, certain ifdefs don't seem to be working on my machine (HAVE_OMP_H, HAVE_SCHED_H, HAVE_UNISTD_H). Not sure what that's about, automake should take care of that.